### PR TITLE
Fix order of commands in README.md and minor issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,24 +2,30 @@
 
 ### Run this application with Node 14
 
-1. Install dependencies
-```
-$ yarn 
-```
-2. Copy `.env.example` as `.env.local`
+1. Copy `.env.example` as `.env.local`
+
 ```
 $ cp .env.example .env.local
 ```
+
+2. Install dependencies
+
+```
+$ yarn
+```
+
 3. Auto generate generate contracts types, subgraph types & queries SDK
+
 ```
 $ yarn postinstall
 ```
-* NOTE: `postinstall` will generates an sdk file in `CODEGEN_OUTPUT_FILE` environment variable (default value: `types/generated/queries.ts` ) with all queries uses in the App.
+
+- NOTE: `postinstall` will generates an sdk file in `CODEGEN_OUTPUT_FILE` environment variable (default value: `types/generated/queries.ts` ) with all queries uses in the App.
 
 4. Run application as dev mode
+
 ```
 $ yarn dev
 ```
-4. Open `http://localhost:3000`
 
-
+5. Open `http://localhost:3000`


### PR DESCRIPTION
First and second steps in readme should be switched because in codegen.js `process.env.NEXT_PUBLIC_GRAPH_ENDPOINT_KOVAN` used, but we make env file only on the second step. So `graphql-codegen --config codegen.js` ends with Error: Query root type must be provided.