### PR TITLE
New stake section sidebar UI

### DIFF
--- a/src/components/pureStyledComponents/common/Filters.tsx
+++ b/src/components/pureStyledComponents/common/Filters.tsx
@@ -1,0 +1,8 @@
+import styled from 'styled-components'
+
+export const Filters = styled.div<{ justifyContent: 'space-between' | 'flex-start' }>`
+  display: flex;
+  gap: 6px;
+  justify-content: ${({ justifyContent }) => justifyContent}};
+  margin-bottom: 20px;
+`

--- a/src/components/sidebar/AelinData.tsx
+++ b/src/components/sidebar/AelinData.tsx
@@ -1,6 +1,9 @@
+import { useState } from 'react'
 import styled from 'styled-components'
 
+import { Filters } from '../pureStyledComponents/common/Filters'
 import { GradientButton } from '@/src/components/pureStyledComponents/buttons/Button'
+import { TabButton } from '@/src/components/pureStyledComponents/buttons/Button'
 
 const Wrapper = styled.div`
   margin-bottom: 40px;
@@ -31,14 +34,30 @@ const ButtonContainer = styled.div`
   justify-content: center;
 `
 
+enum Tab {
+  Aelin = 'Aelin',
+  EthAelin = 'EthAelin',
+}
+
+function getBalanceTitle(activeTab: Tab): string {
+  switch (activeTab) {
+    case Tab.Aelin:
+      return 'Aelin balance:'
+    case Tab.EthAelin:
+      return 'ETH/Aelin balance:'
+  }
+}
+
 const AelinData: React.FC = ({ ...restProps }) => {
+  const [activeTab, setActiveTab] = useState<Tab>(Tab.Aelin)
+
   const data = [
     {
-      title: 'Aelin balance:',
+      title: getBalanceTitle(activeTab),
       value: '0.25465487',
     },
     {
-      title: 'Aelin staking:',
+      title: 'My stake:',
       value: '1.7548656',
     },
     {
@@ -49,6 +68,24 @@ const AelinData: React.FC = ({ ...restProps }) => {
 
   return (
     <Wrapper {...restProps}>
+      <Filters justifyContent="flex-start">
+        <TabButton
+          isActive={activeTab === Tab.Aelin}
+          onClick={() => {
+            setActiveTab(Tab.Aelin)
+          }}
+        >
+          Aelin
+        </TabButton>
+        <TabButton
+          isActive={activeTab === Tab.EthAelin}
+          onClick={() => {
+            setActiveTab(Tab.EthAelin)
+          }}
+        >
+          ETH/Aelin
+        </TabButton>
+      </Filters>
       <Rows>
         {data.map(({ title, value }, index) => (
           <Row key={index}>

--- a/src/components/sidebar/MyPools.tsx
+++ b/src/components/sidebar/MyPools.tsx
@@ -1,17 +1,11 @@
 import React, { useState } from 'react'
 import styled from 'styled-components'
 
+import { Filters } from '../pureStyledComponents/common/Filters'
 import { TabButton } from '@/src/components/pureStyledComponents/buttons/Button'
 import CollapsibleBlock from '@/src/components/sidebar/CollapsibleBlock'
 import Pool from '@/src/components/sidebar/Pool'
 import { RequiredConnection } from '@/src/hooks/requiredConnection'
-
-const Filters = styled.div`
-  display: flex;
-  gap: 4px;
-  justify-content: space-between;
-  margin-bottom: 20px;
-`
 
 const MoreButton = styled(TabButton)`
   border-color: ${({ theme: { colors } }) => colors.textColor};
@@ -51,7 +45,7 @@ const MyPools: React.FC = ({ ...restProps }) => {
 
   return (
     <CollapsibleBlock title={'My pools'} {...restProps}>
-      <Filters>
+      <Filters justifyContent="space-between">
         <TabButton
           isActive={activeFilter === 'invested'}
           onClick={() => {

--- a/src/components/stake/ClaimBox.tsx
+++ b/src/components/stake/ClaimBox.tsx
@@ -80,7 +80,7 @@ const ClaimBox: FC<ClaimBoxProps> = ({ stakingAddress, userRewards }) => {
     <Wrapper>
       <Title>Claim rewards</Title>
       <Text>
-        My Rewards: <Value>{rewardsToClaim} AELIN</Value>
+        My rewards: <Value>{rewardsToClaim} AELIN</Value>
       </Text>
       <Button
         disabled={BigNumber.from(rewardsToClaim).eq(ZERO_BN) || isSubmitting}

--- a/src/components/stake/StakeInfo.tsx
+++ b/src/components/stake/StakeInfo.tsx
@@ -51,7 +51,7 @@ const StakeInfo: FC<StakeInfoProps> = ({ isPool2, rewards, ...restProps }) => {
       {!isPool2 && (
         <>
           <Text>
-            Aelin staking:{' '}
+            Total Aelin staked:{' '}
             <Value>{`${rewards?.totalAelinStaked?.toFixed(2) ?? 0} ${rewards?.symbol}`}</Value>
           </Text>
           <Text>


### PR DESCRIPTION
UI part of #27

Stake section of sidebar was changed accordingly to the new design: https://www.figma.com/file/ZBGhsSy6bQOB6XxNHSlBiF/V2?node-id=2957%3A39265

Also additional refactoring of logic is needed to close #27 completely