### PR TITLE
Fix: Approve Component wording

### DIFF
--- a/src/components/pools/actions/Approve.tsx
+++ b/src/components/pools/actions/Approve.tsx
@@ -7,12 +7,19 @@ import { useWeb3Connection } from '@/src/providers/web3ConnectionProvider'
 
 type Props = {
   tokenAddress: string
-  tokenSymbol: string
   spender: string
+  title: string
+  description: string
   refetchAllowance: () => void
 }
 
-export default function Approve({ refetchAllowance, spender, tokenAddress, tokenSymbol }: Props) {
+export default function Approve({
+  description,
+  refetchAllowance,
+  spender,
+  title,
+  tokenAddress,
+}: Props) {
   const { address, isAppConnected } = useWeb3Connection()
 
   const { isSubmitting, setConfigAndOpenModal } = useTransactionModal()
@@ -27,16 +34,14 @@ export default function Approve({ refetchAllowance, spender, tokenAddress, token
           refetchAllowance()
         }
       },
-      title: `Approve ${tokenSymbol}`,
+      title: `${title}`,
       estimate: () => estimate([spender, MAX_BN]),
     })
   }
 
   return (
     <>
-      <Contents>
-        Before you deposit, the pool needs your permission to transfer your {tokenSymbol}
-      </Contents>
+      <Contents>{description}</Contents>
       <GradientButton
         disabled={!address || !isAppConnected || isSubmitting}
         onClick={approveInvestmentToken}

--- a/src/components/pools/actions/FundDeal.tsx
+++ b/src/components/pools/actions/FundDeal.tsx
@@ -25,10 +25,11 @@ const FundDeal: React.FC<Props> = ({ pool, ...restProps }) => {
     <Wrapper title="Deposit tokens" {...restProps}>
       {(allowance || ZERO_BN).lt(pool.deal?.underlyingToken.dealAmount.raw || ZERO_BN) ? (
         <Approve
+          description={`Before funding the deal, you need to approve the pool to transfer your ${pool.deal?.underlyingToken.symbol}`}
           refetchAllowance={refetch}
           spender={pool.dealAddress || ZERO_ADDRESS}
+          title="Fund deal"
           tokenAddress={pool.deal?.underlyingToken.token || ZERO_ADDRESS}
-          tokenSymbol={pool.deal?.underlyingToken.symbol || ''}
         />
       ) : (
         <HolderDeposit pool={pool} />

--- a/src/components/pools/actions/Invest.tsx
+++ b/src/components/pools/actions/Invest.tsx
@@ -22,10 +22,11 @@ const Invest: React.FC<Props> = ({ pool, poolHelpers, ...restProps }) => {
         <Deposit pool={pool} poolHelpers={poolHelpers} />
       ) : (
         <Approve
+          description={`Before you can deposit, the pool needs your permission to transfer your ${pool.investmentTokenSymbol}`}
           refetchAllowance={poolHelpers.refetchUserAllowance}
           spender={pool.address}
+          title="Deposit tokens"
           tokenAddress={pool.investmentToken}
-          tokenSymbol={pool.investmentTokenSymbol}
         />
       )}
     </Wrapper>


### PR DESCRIPTION
Closes #192.

The Approve component was showing an incorrect description.
As it's a generic component I refactored it so it receives `title` and `description` as props. 