### PR TITLE
(Bug) PoolTimeline openRedemption

### DIFF
--- a/src/hooks/aelin/useAelinPoolStatus.ts
+++ b/src/hooks/aelin/useAelinPoolStatus.ts
@@ -491,7 +491,11 @@ export function useTimelineStatus(pool?: ParsedAelinPool, now: number = Date.now
         active:
           !!pool?.deal?.holderAlreadyDeposited &&
           !!pool?.deal.redemption?.openRedemptionEnd &&
-          isBefore(now, pool.deal.redemption.openRedemptionEnd),
+          !!pool?.deal.redemption?.proRataRedemptionEnd &&
+          isWithinInterval(now, {
+            start: pool.deal.redemption.proRataRedemptionEnd,
+            end: pool.deal.redemption.openRedemptionEnd,
+          }),
         isDone:
           !!pool?.deal?.holderAlreadyDeposited &&
           !!pool?.deal.redemption?.openRedemptionEnd &&


### PR DESCRIPTION
Closes #339 

When a user is at the Pro Rata Redemption stage, the downwards Timeline progress bar should stop at the Pro Rata Redemption card.
![image](https://user-images.githubusercontent.com/99757679/170314212-4f630cdc-60f1-4cee-a135-c796640f8652.png)

