### PR TITLE
(Bug) DealOpenPeriod in timeline 

### DIFF
--- a/src/hooks/aelin/useAelinPool.tsx
+++ b/src/hooks/aelin/useAelinPool.tsx
@@ -188,7 +188,7 @@ export const getParsedPool = ({
       dealDetails.vestingCliff,
       dealDetails.vestingPeriod,
     ),
-    hasDealOpenPeriod: !!dealDetails.openRedemptionStart,
+    hasDealOpenPeriod: dealDetails.openRedemptionStart && dealDetails.openRedemptionStart !== '0',
     redemption: redemptionInfo,
     holderAlreadyDeposited: dealDetails.isDealFunded,
     holderFundingExpiration: new Date(dealDetails.holderFundingExpiration * 1000),


### PR DESCRIPTION
Closes #363 

If the pool has an openPeriod equals to 0, the timeline should hide the OpenPeriod card.