### PR TITLE
(BUG) Token totals investment token wrong amt

### DIFF
--- a/src/components/pools/deal/DealInformation.tsx
+++ b/src/components/pools/deal/DealInformation.tsx
@@ -71,7 +71,7 @@ export const DealInformation: React.FC<{
           tooltip="The total amount of investment tokens funded and deal tokens available"
         >
           <StyledValue>
-            Investment token: {pool.funded.formatted}{' '}
+            Investment token: {deal.underlyingToken.investmentAmount.formatted}{' '}
             <ExternalLink
               href={getExplorerUrl(pool.investmentToken, chainId)}
               label={pool.investmentTokenSymbol}

--- a/src/hooks/aelin/useAelinPool.tsx
+++ b/src/hooks/aelin/useAelinPool.tsx
@@ -15,6 +15,7 @@ import {
   getDealDeadline,
   getDetailedNumber,
   getFunded,
+  getInvestmentDealToken,
   getPoolCreatedDate,
   getProRataRedemptionDates,
   getPurchaseExpiry,
@@ -67,6 +68,7 @@ export type ParsedAelinPool = {
       // totalSupply: DetailedNumber
       // The amount of underlying tokens for the deal, for example the Sponsor offers 500k USD in exchange of the invested tokens.
       dealAmount: DetailedNumber
+      investmentAmount: DetailedNumber
     }
     //purchaseTokensForDeal:
     exchangeRates: {
@@ -188,6 +190,11 @@ export const getParsedPool = ({
       dealAmount: getDetailedNumber(
         dealDetails.underlyingDealTokenTotal,
         dealDetails.underlyingDealTokenDecimals,
+      ),
+      investmentAmount: getInvestmentDealToken(
+        dealDetails.underlyingDealTokenTotal,
+        dealDetails.underlyingDealTokenDecimals,
+        exchangeRates.investmentPerDeal,
       ),
     },
     exchangeRates,

--- a/src/utils/aelinPoolUtils.ts
+++ b/src/utils/aelinPoolUtils.ts
@@ -278,3 +278,17 @@ export function getTokensSold(
     formatted: formatToken(tokensSold, investmentTokenDecimals),
   }
 }
+
+export function getInvestmentDealToken(
+  underlyingDealTokenTotal: string,
+  underlyingDecimals: number,
+  exchangeRate: DetailedNumber,
+) {
+  const _underlyingDealTokenTotal = new Wei(underlyingDealTokenTotal, underlyingDecimals, true)
+  const _exchangeRate = new Wei(exchangeRate.raw, underlyingDecimals, true)
+  const _investmentDealToken = _underlyingDealTokenTotal.mul(_exchangeRate).toBN()
+  return {
+    raw: _investmentDealToken,
+    formatted: formatToken(_investmentDealToken, underlyingDecimals),
+  }
+}


### PR DESCRIPTION
Closes #466 

This PR solves the bug located in the Token totals: investment token, where if the deal is partially funded, then the investment token is shown as if the deal was fully funded