### PR TITLE
Sidebar - Fix My Pools empty state

### DIFF
--- a/src/components/sidebar/MyPools.tsx
+++ b/src/components/sidebar/MyPools.tsx
@@ -32,11 +32,12 @@ const EmptyPools = styled.div`
   display: flex;
   flex-direction: column;
   flex-grow: 0;
-  font-size: 1.4rem;
+  font-size: 1.2rem;
   font-weight: 500;
-  height: 36px;
   justify-content: center;
   white-space: normal;
+  padding: 12px;
+  text-align: center;
 `
 
 const MoreButton = styled(TabButton)`


### PR DESCRIPTION
Closes #518 

Before:
<img width="251" alt="Screen Shot 2022-06-14 at 22 36 20" src="https://user-images.githubusercontent.com/15804684/173720175-d9d839d5-fa3f-4492-9e58-806239f3cce8.png">


Now:
<img width="248" alt="Screen Shot 2022-06-14 at 22 36 05" src="https://user-images.githubusercontent.com/15804684/173720000-04c762a8-2063-489b-9e39-fb50f050529e.png">
