### PR TITLE
[Bug] Accepted all allocation message

### DIFF
--- a/src/components/pools/PoolMain.tsx
+++ b/src/components/pools/PoolMain.tsx
@@ -2,6 +2,7 @@ import Head from 'next/head'
 import { useRouter } from 'next/router'
 import styled from 'styled-components'
 
+import NoActions from './actions/NoActions'
 import { NotificationType } from '@/graphql-schema'
 import { ActionTabs } from '@/src/components/common/ActionTabs'
 import {
@@ -28,7 +29,7 @@ import useAelinPoolStatus from '@/src/hooks/aelin/useAelinPoolStatus'
 import { useCheckVerifiedPool } from '@/src/hooks/aelin/useCheckVerifiedPool'
 import { RequiredConnection } from '@/src/hooks/requiredConnection'
 import { getExplorerUrl } from '@/src/utils/getExplorerUrl'
-import { PoolAction, PoolStatus, PoolTab } from '@/types/aelinPool'
+import { PoolAction, PoolTab } from '@/types/aelinPool'
 
 const MainGrid = styled.div`
   column-gap: 65px;
@@ -126,14 +127,7 @@ export default function PoolMain({ chainId, poolAddress }: Props) {
               networkToCheck={pool.chainId}
             >
               <>
-                {!tabs.actionTabs.states.length && (
-                  <div>
-                    {derivedStatus.current === PoolStatus.DealPresented
-                      ? 'You have not participated in this pool'
-                      : 'No actions available'}
-                  </div>
-                )}
-
+                {!tabs.actionTabs.states.length && <NoActions pool={pool} status={derivedStatus} />}
                 {tabs.actionTabs.active === PoolAction.Invest && (
                   <Invest pool={pool} poolHelpers={funding} />
                 )}

--- a/src/components/pools/actions/NoActions.tsx
+++ b/src/components/pools/actions/NoActions.tsx
@@ -1,0 +1,29 @@
+import { genericSuspense } from '../../helpers/SafeSuspense'
+import { ZERO_ADDRESS, ZERO_BN } from '@/src/constants/misc'
+import { ParsedAelinPool } from '@/src/hooks/aelin/useAelinPool'
+import useAelinDealCall from '@/src/hooks/contracts/useAelinDealCall'
+import { useWeb3Connection } from '@/src/providers/web3ConnectionProvider'
+import { DerivedStatus, PoolStatus } from '@/types/aelinPool'
+
+const NoActions = ({ pool, status }: { status: DerivedStatus; pool: ParsedAelinPool }) => {
+  const { address, appChainId } = useWeb3Connection()
+
+  const [dealTokenBalance] = useAelinDealCall(
+    appChainId,
+    pool.dealAddress || ZERO_ADDRESS,
+    'balanceOf',
+    [address || ZERO_ADDRESS],
+  )
+
+  return (
+    <div>
+      {status.current === PoolStatus.DealPresented
+        ? dealTokenBalance?.gt(ZERO_BN)
+          ? 'You have accepted your full allocation'
+          : 'You have not participated in this pool'
+        : 'No actions available'}
+    </div>
+  )
+}
+
+export default genericSuspense(NoActions)

--- a/src/hooks/aelin/useAelinPoolStatus.ts
+++ b/src/hooks/aelin/useAelinPoolStatus.ts
@@ -445,7 +445,6 @@ function useUserTabs(
           }
           break
         case NotificationType.FundingWindowEnded:
-          console.log(userRole)
           setActiveTab(PoolTab.PoolInformation)
           userRole === UserRole.Sponsor
             ? setActiveAction(PoolAction.CreateDeal)


### PR DESCRIPTION
Closes #614

If a user accepted all his allocation during Round 1 or 2 the message shown was incorrect: 
`You have not participated in this pool`

This PR fixes that and if a user has accepted all his allocation then the message will be: 
`You have accepted your full allocation`

