### PR TITLE
AELIP-15: [Bug] Blacklisted by error

### DIFF
--- a/src/hooks/aelin/useUserNftsByCollections.tsx
+++ b/src/hooks/aelin/useUserNftsByCollections.tsx
@@ -28,9 +28,12 @@ const useUserNftsByCollections = (pool: ParsedAelinPool) => {
     revalidateOnMount: true,
   })
 
-  const isNftBlackListed = (tokenId: string) => {
+  const isNftBlackListed = (tokenId: string, collectionAddress: string) => {
     return !!nftCollectionRules?.some((collectionRule) => {
-      return collectionRule.erc721Blacklisted.indexOf(tokenId) !== -1
+      return (
+        collectionRule.erc721Blacklisted.indexOf(tokenId) !== -1 &&
+        collectionAddress === collectionRule.collectionAddress.toLowerCase()
+      )
     })
   }
 
@@ -50,7 +53,7 @@ const useUserNftsByCollections = (pool: ParsedAelinPool) => {
       [`${curr.contractAddress.toLowerCase()}-${curr.id}`]: {
         ...curr,
         contractAddress: curr.contractAddress.toLowerCase(),
-        blackListed: isNftBlackListed(curr.id),
+        blackListed: isNftBlackListed(curr.id, curr.contractAddress.toLowerCase()),
         balance: balances?.length ? balances[index] : BigNumber.from(0),
       },
     }),


### PR DESCRIPTION
Closes #633 

To balcklist NFTs we were looking at the nftId **only**. So if 2 NFTs share the same id, then both would be blacklisted. To fix this, we need to take into account the collectionAddress