### PR TITLE
[Feat] Verify NFT validity and eligibility

### DIFF
--- a/src/components/pools/actions/Invest/nft/NftCollectionRulesCarousel.tsx
+++ b/src/components/pools/actions/Invest/nft/NftCollectionRulesCarousel.tsx
@@ -1,9 +1,10 @@
-import { useMemo, useRef, useState } from 'react'
+import { useMemo, useRef } from 'react'
 import styled from 'styled-components'
 
 import chunk from 'lodash/chunk'
 import { isMobile } from 'react-device-detect'
 
+import NftEligibility from './NftEligibility'
 import NftMedia from './NftMedia'
 import {
   ButtonNext,
@@ -18,7 +19,6 @@ import { VerifiedNftCollection as VerifiedIcon } from '@/src/components/assets/V
 import { Loading } from '@/src/components/common/Loading'
 import { genericSuspense } from '@/src/components/helpers/SafeSuspense'
 import { BaseCard } from '@/src/components/pureStyledComponents/common/BaseCard'
-import { Search } from '@/src/components/pureStyledComponents/form/Search'
 import { ExternalLink } from '@/src/components/table/ExternalLink'
 import { Chains } from '@/src/constants/chains'
 import { OPENSEA_BASE_URL, QUIXOTIC_BASE_URL, ZERO_BN } from '@/src/constants/misc'
@@ -27,7 +27,6 @@ import useNftCollectionLists, {
   NFTType,
   NftCollectionData,
 } from '@/src/hooks/aelin/useNftCollectionLists'
-import { useWeb3Connection } from '@/src/providers/web3ConnectionProvider'
 import { strToKebabCase } from '@/src/utils/string'
 import { formatToken } from '@/src/web3/bigNumber'
 
@@ -62,26 +61,6 @@ const Title = styled.h1`
   font-size: 1.4rem;
   line-height: 1.4;
 `
-const SubTitle = styled.div`
-  color: ${({ theme: { colors } }) => colors.textColor};
-  font-weight: 400;
-  font-size: 1.25rem;
-  line-height: 1rem;
-  padding-bottom: 1rem;
-`
-
-const Eligible = styled.div`
-  color: ${({ theme }) => theme.colors.textColor};
-  font-size: 1.25rem;
-  font-weight: 400;
-  line-height: 1.2;
-  margin: 1rem;
-  min-height: 15px;
-`
-
-const EligibleError = styled.span`
-  color: #ff7777;
-`
 
 const CollectionRulesWrapper = styled.div<{ arrowsVisible: boolean }>`
   position: relative;
@@ -110,11 +89,6 @@ type NftCollectionRulesCarouselProps = {
 const RULES_PER_GROUP = 3
 
 const NftCollectionRulesCarousel = ({ collection, pool }: NftCollectionRulesCarouselProps) => {
-  const { appChainId } = useWeb3Connection()
-  const [eligible, setEligible] = useState<boolean>()
-  const [tokenId, setTokenId] = useState<string>()
-  const searchRef = useRef<HTMLInputElement>(null)
-
   const rules = pool.nftCollectionRules.find(
     (rules) => rules.collectionAddress.toLowerCase() === collection.address.toLowerCase(),
   )
@@ -165,36 +139,7 @@ const NftCollectionRulesCarousel = ({ collection, pool }: NftCollectionRulesCaro
       </Row>
       <AllocationText>{ruleText}:</AllocationText>
       <AllocationValue>{ruleAllocation}</AllocationValue>
-      {rules.nftType === 'ERC721' && (
-        <>
-          <Title>Verify NFT ID eligibility</Title>
-          <SubTitle> Each ID may only be used once per pool</SubTitle>
-          <Search
-            onChange={(e) => {
-              setTokenId(e.target.value)
-              setEligible(!rules.erc721Blacklisted.includes(e.target.value))
-            }}
-            placeholder="Enter NFT ID..."
-            ref={searchRef}
-            type="number"
-          />
-          <Eligible>
-            {tokenId && tokenId !== '' ? (
-              eligible ? (
-                <>
-                  NFT Id <b>{tokenId}</b> is eligible to invest.
-                </>
-              ) : (
-                <EligibleError>
-                  NFT Id <b>{tokenId}</b> is <b>NOT</b> eligible to invest.
-                </EligibleError>
-              )
-            ) : (
-              <></>
-            )}
-          </Eligible>
-        </>
-      )}
+      {rules.nftType === 'ERC721' && <NftEligibility rules={rules} />}
     </Card>
   )
 }

--- a/src/components/pools/actions/Invest/nft/NftEligibility.tsx
+++ b/src/components/pools/actions/Invest/nft/NftEligibility.tsx
@@ -1,0 +1,100 @@
+import { useMemo, useRef, useState } from 'react'
+import styled from 'styled-components'
+
+import { debounce } from 'lodash'
+
+import { genericSuspense } from '@/src/components/helpers/SafeSuspense'
+import { Search } from '@/src/components/pureStyledComponents/form/Search'
+import { DEBOUNCED_INPUT_TIME } from '@/src/constants/misc'
+import useNftEligible from '@/src/hooks/aelin/nft/useNftEligible'
+import { ParsedNftCollectionRules } from '@/src/utils/aelinPoolUtils'
+
+const Title = styled.h1`
+  color: ${({ theme: { colors } }) => colors.textColor};
+  font-weight: 600;
+  font-size: 1.4rem;
+  line-height: 1.4;
+`
+const SubTitle = styled.div`
+  color: ${({ theme: { colors } }) => colors.textColor};
+  font-weight: 400;
+  font-size: 1.25rem;
+  line-height: 1rem;
+  padding-bottom: 1rem;
+`
+
+const Eligible = styled.div`
+  color: ${({ theme }) => theme.colors.textColor};
+  font-size: 1.25rem;
+  font-weight: 400;
+  line-height: 1.2;
+  margin: 1rem;
+  min-height: 15px;
+`
+
+const EligibleError = styled.span`
+  color: #ff7777;
+`
+
+const Verifying = styled(Eligible)`
+  font-style: italic;
+`
+
+type NftEligibilityProps = {
+  rules: ParsedNftCollectionRules
+}
+
+type EligibilityProps = {
+  rules: ParsedNftCollectionRules
+  tokenId?: string
+}
+
+const Eligibility: React.FC<EligibilityProps> = genericSuspense(
+  ({ rules, tokenId }) => {
+    const eligible = useNftEligible(rules, tokenId)
+    return (
+      <Eligible>
+        {tokenId && tokenId !== '' ? (
+          eligible ? (
+            <>
+              NFT Id <b>{tokenId}</b> is eligible to invest.
+            </>
+          ) : (
+            <EligibleError>
+              NFT Id <b>{tokenId}</b> is <b>NOT</b> eligible to invest.
+            </EligibleError>
+          )
+        ) : (
+          <></>
+        )}
+      </Eligible>
+    )
+  },
+  () => <Verifying>Verifying token...</Verifying>,
+)
+
+const NftEligibility: React.FC<NftEligibilityProps> = ({ rules }) => {
+  const [tokenId, setTokenId] = useState<string>()
+  const searchRef = useRef<HTMLInputElement>(null)
+
+  const debouncedSetTokenId = useMemo(
+    () => debounce(setTokenId, DEBOUNCED_INPUT_TIME),
+    [setTokenId],
+  )
+
+  return (
+    <>
+      <Title>Verify NFT ID eligibility</Title>
+      <SubTitle> Each ID may only be used once per pool</SubTitle>
+      <Search
+        onChange={(e) => debouncedSetTokenId(e.target.value)}
+        placeholder="Enter NFT ID..."
+        ref={searchRef}
+        type="number"
+      />
+      <Eligibility rules={rules} tokenId={tokenId} />
+    </>
+  )
+}
+
+export default NftEligibility

--- a/src/components/pools/actions/Invest/nft/NftEligibility.tsx
+++ b/src/components/pools/actions/Invest/nft/NftEligibility.tsx
@@ -54,8 +54,9 @@ const Eligibility: React.FC<EligibilityProps> = genericSuspense(
     const eligible = useNftEligible(rules, tokenId)
     return (
       <Eligible>
-        {tokenId && tokenId !== '' ? (
-          eligible ? (
+        {tokenId &&
+          tokenId !== '' &&
+          (eligible ? (
             <>
               NFT Id <b>{tokenId}</b> is eligible to invest.
             </>
@@ -63,10 +64,7 @@ const Eligibility: React.FC<EligibilityProps> = genericSuspense(
             <EligibleError>
               NFT Id <b>{tokenId}</b> is <b>NOT</b> eligible to invest.
             </EligibleError>
-          )
-        ) : (
-          <></>
-        )}
+          ))}
       </Eligible>
     )
   },

--- a/src/hooks/aelin/nft/useNftEligible.tsx
+++ b/src/hooks/aelin/nft/useNftEligible.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useMemo, useState } from 'react'
+
+import { BigNumber } from '@ethersproject/bignumber'
+
+import useERC721Call from '../../contracts/useERC721Call'
+import { ZERO_ADDRESS } from '@/src/constants/misc'
+import { useWeb3Connection } from '@/src/providers/web3ConnectionProvider'
+import { ParsedNftCollectionRules } from '@/src/utils/aelinPoolUtils'
+
+//Check Eligibility for ERC721
+const useNftEligible = (rules?: ParsedNftCollectionRules, tokenId?: string) => {
+  const { appChainId } = useWeb3Connection()
+  const [eligible, setEligible] = useState<boolean>(false)
+  const [isTokenValid] = useERC721Call(
+    appChainId,
+    rules?.collectionAddress || ZERO_ADDRESS,
+    'ownerOf',
+    [tokenId ? BigNumber.from(tokenId) : ''],
+  )
+
+  useEffect(() => {
+    if (rules && tokenId) {
+      if (!isTokenValid) {
+        setEligible(false)
+      } else if (rules.erc721Blacklisted.includes(tokenId)) {
+        setEligible(false)
+      } else {
+        setEligible(true)
+      }
+    }
+  }, [rules, tokenId, isTokenValid])
+
+  return eligible
+}
+
+export default useNftEligible

--- a/src/hooks/contracts/useERC721Call.ts
+++ b/src/hooks/contracts/useERC721Call.ts
@@ -1,0 +1,22 @@
+import { JsonRpcProvider } from '@ethersproject/providers'
+
+import useContractCall from './useContractCall'
+import erc721 from '@/src/abis/ERC721.json'
+import { ChainsValues, getNetworkConfig } from '@/src/constants/chains'
+import { ERC721 } from '@/types/typechain'
+
+export default function useERC721Call<
+  MethodName extends keyof ERC721['functions'],
+  Params extends Parameters<ERC721[MethodName]> | null,
+  Return extends Awaited<ReturnType<ERC721[MethodName]>>,
+>(
+  chainId: ChainsValues,
+  address: string,
+  method: MethodName,
+  params: Params,
+): [Return | null, () => void] {
+  const provider = new JsonRpcProvider(getNetworkConfig(chainId).rpcUrl)
+
+  const [data, refetch] = useContractCall(provider, address, erc721, method, params)
+  return [data, refetch]
+}


### PR DESCRIPTION
This PR adds a verification layer on top of the one already implemented (check if the erc721 already used).
Currently if an investor types an invalid NFT Id, the verification process will pass since the NFT(invalid) is not black listed.
This PR solves that by first verifying NFT validity

Closes #698 