### PR TITLE
InvestorsModal now sortable by AmountInvested or UserAddress

### DIFF
--- a/src/components/pools/common/InvestorsModal.tsx
+++ b/src/components/pools/common/InvestorsModal.tsx
@@ -145,22 +145,35 @@ const InvestorsTable = genericSuspense(
   ({ pool }: { pool: ParsedAelinPool }) => {
     const router = useRouter()
     const [orderDirection, setOrderDirection] = useState<OrderDirection>(OrderDirection.Desc)
+    const [sortBy, setSortBy] = useState<Investor_OrderBy | undefined>(
+      Investor_OrderBy.AmountInvested,
+    )
 
     const { data, hasMore, nextPage } = useAelinInvestors({
-      orderDirection: OrderDirection.Desc,
+      orderBy: sortBy,
+      orderDirection: orderDirection,
       where: {
         poolAddress: pool.address,
       },
     })
 
-    const handleSort = () => {
-      if (orderDirection === OrderDirection.Desc) return setOrderDirection(OrderDirection.Asc)
-      setOrderDirection(OrderDirection.Desc)
+    const handleSort = (orderBy: Investor_OrderBy | undefined) => {
+      if (sortBy === orderBy) {
+        if (orderDirection === OrderDirection.Desc) {
+          setOrderDirection(OrderDirection.Asc)
+        } else {
+          setOrderDirection(OrderDirection.Desc)
+        }
+      } else {
+        setSortBy(orderBy)
+        setOrderDirection(OrderDirection.Desc)
+      }
     }
 
     const tableHeaderCells = [
       {
         title: 'Address or ens',
+        sortKey: Investor_OrderBy.UserAddress,
       },
       {
         title: 'Amount invested',
@@ -184,7 +197,7 @@ const InvestorsTable = genericSuspense(
                 key={index}
                 onClick={() => {
                   if (sortKey) {
-                    handleSort()
+                    handleSort(sortKey)
                   }
                 }}
               >

--- a/src/components/pools/common/InvestorsModal.tsx
+++ b/src/components/pools/common/InvestorsModal.tsx
@@ -157,15 +157,15 @@ const InvestorsTable = genericSuspense(
       },
     })
 
-    const handleSort = (orderBy: Investor_OrderBy | undefined) => {
-      if (sortBy === orderBy) {
+    const handleSort = (newSortBy: Investor_OrderBy | undefined) => {
+      if (sortBy === newSortBy) {
         if (orderDirection === OrderDirection.Desc) {
           setOrderDirection(OrderDirection.Asc)
         } else {
           setOrderDirection(OrderDirection.Desc)
         }
       } else {
-        setSortBy(orderBy)
+        setSortBy(newSortBy)
         setOrderDirection(OrderDirection.Desc)
       }
     }

--- a/src/hooks/aelin/useAelinInvestors.tsx
+++ b/src/hooks/aelin/useAelinInvestors.tsx
@@ -33,15 +33,9 @@ export async function fetcherUsers(variables: QueryInvestorsArgs) {
   try {
     const investorResponses = await Promise.allSettled(queryPromises())
 
-    let result = investorResponses
+    const result = investorResponses
       .filter(isSuccessful)
       .reduce((resultAcc: Investor[], { value }) => [...resultAcc, ...value], [])
-
-    result = orderBy(
-      result,
-      variables.orderBy as Investor_OrderBy,
-      variables.orderDirection ? [variables.orderDirection] : ['desc'],
-    )
 
     return result
   } catch (err) {


### PR DESCRIPTION
This solves issue #953

A couple of notes:

1. This is my first pull request in Aelin. I tried to match my coding style to yours while keeping things simple. Please correct me if I did anything wrong and let me know about improvements;
2. I took the liberty of also allowing users to sort by investor address. I did this because the header was already sortable (but had no functionality) and because it can be helpful to look up investors.