### PR TITLE
Fix Pool/deal creation screen layout issues (issue #964)

### DIFF
--- a/src/components/pools/common/Summary.tsx
+++ b/src/components/pools/common/Summary.tsx
@@ -12,7 +12,7 @@ const Wrapper = styled.div`
   padding: 20px;
   width: 100%;
 
-  @media (min-width: ${({ theme }) => theme.themeBreakPoints.tabletPortraitStart}) {
+  @media (min-width: ${({ theme }) => theme.themeBreakPoints.desktopWideStart}) {
     grid-auto-flow: column;
   }
 `

--- a/src/hooks/aelin/useAelinCreateUpFrontDeal.tsx
+++ b/src/hooks/aelin/useAelinCreateUpFrontDeal.tsx
@@ -37,7 +37,6 @@ import { storeJson } from '@/src/utils/web3storage'
 const VestinScheduleContainer = styled.div`
   display: flex;
   flex-direction: column;
-  white-space: nowrap;
 `
 
 export enum CreateUpFrontDealSteps {


### PR DESCRIPTION
This fixes issue #964 by doing two things:

1. It applies the `grid-auto-flow: column` for screens at least as wide as `desktopWideStart` instead of `tabletPortraitStart`, thus allowing the default behavior of filling the grid by row for relevant screens.

2. Regarding creating deals, the `VestingScheduleContainer` forces `white-space: nowrap` which would cause the same issue for some parameters such as `Redemption deadline` and `Vesting schedule`. Removing this fixes the issue.

![image](https://user-images.githubusercontent.com/52707094/230737308-6c23329c-c085-408a-87da-0182dd6ca84b.png)
