### PR TITLE
Fix pools created count on stats page does not correspond pools list filtered by selected sponsor (#954)

### DIFF
--- a/src/hooks/aelin/useAelinUsers.tsx
+++ b/src/hooks/aelin/useAelinUsers.tsx
@@ -8,6 +8,8 @@ import { ChainsValues, ChainsValuesArray } from '@/src/constants/chains'
 import { SPONSORS_RESULTS_PER_CHAIN } from '@/src/constants/pool'
 import { USERS_QUERY_NAME } from '@/src/queries/pools/users'
 import getAllGqlSDK from '@/src/utils/getAllGqlSDK'
+import { isHiddenPool, isTestPool } from '@/src/utils/isHiddenPool'
+import isProd from '@/src/utils/isProd'
 import { isSuccessful } from '@/src/utils/isSuccessful'
 
 export interface ParsedUserAmt {
@@ -36,7 +38,11 @@ export async function fetcherUsers(variables: UsersQueryVariables) {
               poolsInvestedAmt: user.poolsInvestedAmt,
               poolsVouchedAmt: user.poolsVouchedAmt,
               poolsAsHolderAmt: user.poolsAsHolderAmt,
-              poolsSponsoredAmt: user.poolsSponsoredAmt,
+              poolsSponsoredAmt: user.poolsSponsored.filter((pool) => {
+                if (isTestPool(pool.name) && isProd) return false
+                if (isHiddenPool(pool.id)) return false
+                return true
+              }).length,
               dealsAcceptedAmt: user.dealsAcceptedAmt,
             }
           }),

--- a/src/queries/pools/users.ts
+++ b/src/queries/pools/users.ts
@@ -23,6 +23,10 @@ export const USERS = gql`
       poolsInvestedAmt
       poolsVouchedAmt
       poolsAsHolderAmt
+      poolsSponsored {
+        id
+        name
+      }
       poolsSponsoredAmt
       dealsAcceptedAmt
       upfrontDealsAcceptedAmt


### PR DESCRIPTION
Solves [#954](https://github.com/AelinXYZ/aelin-frontend-v2/issues/954)

the problem was that pools list was filtered by `isHiddenPool` and `isTestPool`, but "Pools created" didn't take that into account. Now total count on stats page correspond pools quantity in ListWithFilters

<img width="1403" alt="image" src="https://user-images.githubusercontent.com/22725775/230944249-01771cbd-a0c2-4879-9c77-bbdcf6729e1f.png">
