### PR TITLE
clear pools_vouched_by input on empty route (home button)

### DIFF
--- a/src/components/pools/list/Vouched.tsx
+++ b/src/components/pools/list/Vouched.tsx
@@ -475,6 +475,14 @@ export const VouchedPools: React.FC = () => {
     }
   }, [searchRef])
 
+  useEffect(() => {
+    const voucherAddress = ensVoucher || voucher
+    if (!voucherAddress) {
+      const input = searchRef.current as HTMLInputElement
+      input.value = aelinVoucherENS
+    }
+  }, [voucher, ensVoucher, searchRef])
+
   return (
     <>
       <Title>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added a useEffect for the VouchedPools component so that the "Pools vouched by" input is cleared when clicking the Home button, so that it correctly matches what the Table Data is displaying.

## Related issue
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/AelinXYZ/aelin-frontend-v2/issues/959

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on dev environment.