### PR TITLE
Fix custom spending cap applying in deposit tokens

### DIFF
--- a/src/components/pools/actions/Deposit/Deposit.tsx
+++ b/src/components/pools/actions/Deposit/Deposit.tsx
@@ -71,8 +71,13 @@ function Deposit({ pool, poolHelpers }: Props) {
   } = useNftSelection()
   const { investmentTokenDecimals, investmentTokenSymbol } = pool
   const allocation = useNftUserAllocation(pool)
-  const { investmentTokenBalance, refetchBalances, userMaxDepositPrivateAmount } =
-    useUserAvailableToDeposit(pool)
+  const {
+    investmentTokenBalance,
+    refetchBalances,
+    refetchUserAllowance,
+    userAllowance,
+    userMaxDepositPrivateAmount,
+  } = useUserAvailableToDeposit(pool)
   const [tokenInputValue, setTokenInputValue] = useState('')
   const [inputError, setInputError] = useState('')
   const { address, isAppConnected } = useWeb3Connection()
@@ -87,6 +92,7 @@ function Deposit({ pool, poolHelpers }: Props) {
 
   const balances = [
     investmentTokenBalance,
+    { ...userAllowance, type: AmountTypes.maxDepositAllowed },
     { ...poolHelpers.maxDepositAllowed, type: AmountTypes.maxDepositAllowed },
   ]
 
@@ -153,6 +159,7 @@ function Deposit({ pool, poolHelpers }: Props) {
           : await purchasePoolTokens([tokenInputValue], txGasOptions)
         if (receipt) {
           refetchBalances()
+          refetchUserAllowance()
           setTokenInputValue('')
           setInputError('')
         }

--- a/src/components/pools/actions/Deposit/DepositDirectDeal.tsx
+++ b/src/components/pools/actions/Deposit/DepositDirectDeal.tsx
@@ -91,8 +91,13 @@ function DepositDirectDeal({ pool, poolHelpers }: Props) {
 
   const allocation = useNftUserAllocation(pool)
 
-  const { investmentTokenBalance, refetchBalances, userMaxDepositPrivateAmount } =
-    useUserAvailableToDepositDirectDeal(pool)
+  const {
+    investmentTokenBalance,
+    refetchBalances,
+    refetchUserAllowance,
+    userAllowance,
+    userMaxDepositPrivateAmount,
+  } = useUserAvailableToDepositDirectDeal(pool)
 
   const [tokenInputValue, setTokenInputValue] = useState('')
   const [inputError, setInputError] = useState('')
@@ -115,6 +120,7 @@ function DepositDirectDeal({ pool, poolHelpers }: Props) {
 
   const balances = [
     investmentTokenBalance,
+    { ...userAllowance, type: AmountTypes.maxDepositAllowed },
     { ...poolHelpers.maxDepositAllowed, type: AmountTypes.maxDepositAllowed },
   ]
 
@@ -184,6 +190,7 @@ function DepositDirectDeal({ pool, poolHelpers }: Props) {
           : await purchasePoolTokens([tokenInputValue], txGasOptions)
         if (receipt) {
           refetchBalances()
+          refetchUserAllowance()
           setTokenInputValue('')
           setInputError('')
         }

--- a/src/components/pools/actions/Invest/Invest.tsx
+++ b/src/components/pools/actions/Invest/Invest.tsx
@@ -7,9 +7,7 @@ import { Contents, Wrapper } from '@/src/components/pools/actions/Wrapper'
 import { ZERO_ADDRESS, ZERO_BN } from '@/src/constants/misc'
 import { ParsedAelinPool } from '@/src/hooks/aelin/useAelinPool'
 import { useUserAvailableToDeposit } from '@/src/hooks/aelin/useUserAvailableToDeposit'
-import useERC20Call from '@/src/hooks/contracts/useERC20Call'
 import { useNftSelection } from '@/src/providers/nftSelectionProvider'
-import { useWeb3Connection } from '@/src/providers/web3ConnectionProvider'
 import { Funding } from '@/types/aelinPool'
 
 type Props = {
@@ -18,17 +16,16 @@ type Props = {
 }
 
 const Invest: React.FC<Props> = ({ pool, poolHelpers, ...restProps }) => {
-  const { address } = useWeb3Connection()
   const { handleCloseNftSelectionModal, hasStoredSelectedNft, showNftSelectionModal } =
     useNftSelection()
-  const [userAllowance, refetchUserAllowance] = useERC20Call(
-    pool.chainId,
-    pool.investmentToken,
-    'allowance',
-    [address || ZERO_ADDRESS, pool.address],
-  )
-  const { isUserAllowedToInvest, userAlreadyInvested, userMaxDepositPrivateAmount } =
-    useUserAvailableToDeposit(pool)
+
+  const {
+    isUserAllowedToInvest,
+    refetchUserAllowance,
+    userAllowance,
+    userAlreadyInvested,
+    userMaxDepositPrivateAmount,
+  } = useUserAvailableToDeposit(pool)
 
   return (
     <Wrapper title="Deposit tokens" {...restProps}>
@@ -40,8 +37,8 @@ const Invest: React.FC<Props> = ({ pool, poolHelpers, ...restProps }) => {
         <Contents>The connected wallet was not allowlisted to invest in this pool.</Contents>
       ) : userAlreadyInvested ? (
         <Contents>This address have already invested in this pool.</Contents>
-      ) : userAllowance.gt(ZERO_ADDRESS) ||
-        (pool.hasNftList && hasStoredSelectedNft && userAllowance.gt(ZERO_ADDRESS)) ? (
+      ) : userAllowance.raw.gt(ZERO_ADDRESS) ||
+        (pool.hasNftList && hasStoredSelectedNft && userAllowance.raw.gt(ZERO_ADDRESS)) ? (
         <Deposit pool={pool} poolHelpers={poolHelpers} />
       ) : pool.hasNftList && !hasStoredSelectedNft ? (
         <SelectNft description="Before you deposit, you need to select the NFT(s) you hold in your wallet in order to unlock deposit." />

--- a/src/components/pools/actions/Invest/InvestDirectDeal.tsx
+++ b/src/components/pools/actions/Invest/InvestDirectDeal.tsx
@@ -7,9 +7,7 @@ import { Contents, Wrapper } from '@/src/components/pools/actions/Wrapper'
 import { ZERO_ADDRESS } from '@/src/constants/misc'
 import { ParsedAelinPool } from '@/src/hooks/aelin/useAelinPool'
 import { useUserAvailableToDepositDirectDeal } from '@/src/hooks/aelin/useUserAvailableToDepositDirectDeal'
-import useERC20Call from '@/src/hooks/contracts/useERC20Call'
 import { useNftSelection } from '@/src/providers/nftSelectionProvider'
-import { useWeb3Connection } from '@/src/providers/web3ConnectionProvider'
 import { isMerklePool, isPrivatePool } from '@/src/utils/aelinPoolUtils'
 import { Funding } from '@/types/aelinPool'
 
@@ -19,19 +17,16 @@ type Props = {
 }
 
 const Invest: React.FC<Props> = ({ pool, poolHelpers, ...restProps }) => {
-  const { address } = useWeb3Connection()
   const { handleCloseNftSelectionModal, hasStoredSelectedNft, showNftSelectionModal } =
     useNftSelection()
 
-  const [userAllowance, refetchUserAllowance] = useERC20Call(
-    pool.chainId,
-    pool.investmentToken,
-    'allowance',
-    [address || ZERO_ADDRESS, pool.address],
-  )
-
-  const { isUserAllowedToInvest, userAlreadyInvested, userMaxDepositPrivateAmount } =
-    useUserAvailableToDepositDirectDeal(pool)
+  const {
+    isUserAllowedToInvest,
+    refetchUserAllowance,
+    userAllowance,
+    userAlreadyInvested,
+    userMaxDepositPrivateAmount,
+  } = useUserAvailableToDepositDirectDeal(pool)
 
   return (
     <Wrapper title="Deposit tokens" {...restProps}>
@@ -43,8 +38,8 @@ const Invest: React.FC<Props> = ({ pool, poolHelpers, ...restProps }) => {
         <Contents>The connected wallet was not allowlisted to invest in this pool.</Contents>
       ) : userAlreadyInvested ? (
         <Contents>This address have already invested in this pool.</Contents>
-      ) : userAllowance.gt(ZERO_ADDRESS) ||
-        (pool.hasNftList && hasStoredSelectedNft && userAllowance.gt(ZERO_ADDRESS)) ? (
+      ) : userAllowance.raw.gt(ZERO_ADDRESS) ||
+        (pool.hasNftList && hasStoredSelectedNft && userAllowance.raw.gt(ZERO_ADDRESS)) ? (
         <DepositDirectDeal pool={pool} poolHelpers={poolHelpers} />
       ) : pool.hasNftList && !hasStoredSelectedNft ? (
         <SelectNft description="Before you deposit, you need to select the NFT(s) you hold in your wallet in order to unlock deposit." />

--- a/src/hooks/aelin/useUserAvailableToDeposit.tsx
+++ b/src/hooks/aelin/useUserAvailableToDeposit.tsx
@@ -23,6 +23,8 @@ export type UserPoolBalance = {
   userMaxDepositPrivateAmount: DetailedNumberExtended
   refetchBalances: () => void
   investmentTokenBalance: DetailedNumberExtended
+  userAllowance: DetailedNumberExtended
+  refetchUserAllowance: () => void
 }
 
 export function useUserAvailableToDeposit(pool: ParsedAelinPool): UserPoolBalance {
@@ -33,6 +35,13 @@ export function useUserAvailableToDeposit(pool: ParsedAelinPool): UserPoolBalanc
     pool.investmentToken,
     'balanceOf',
     [address || ZERO_ADDRESS],
+  )
+
+  const [userAllowance, refetchUserAllowance] = useERC20Call(
+    pool.chainId,
+    pool.investmentToken,
+    'allowance',
+    [address || ZERO_ADDRESS, pool.address],
   )
 
   const [[allowListAmount, userPoolBalance], refetchAllowListBalance] = useAelinPoolCallMultiple(
@@ -70,11 +79,21 @@ export function useUserAvailableToDeposit(pool: ParsedAelinPool): UserPoolBalanc
       ),
       type: AmountTypes.investmentTokenBalance,
     },
+    userAllowance: {
+      raw: userAllowance || ZERO_BN,
+      formatted: formatToken(
+        userAllowance || ZERO_BN,
+        pool.investmentTokenDecimals,
+        DISPLAY_DECIMALS,
+      ),
+      type: AmountTypes.investmentTokenBalance,
+    },
     userAlreadyInvested:
       isUserAllowedToInvest && isPrivatePool(pool.poolType) && allowListAmount.eq(ZERO_BN),
     refetchBalances: () => {
       refetchUserInvestmentTokenBalance()
       isPrivatePool(pool.poolType) && refetchAllowListBalance()
     },
+    refetchUserAllowance,
   }
 }

--- a/src/hooks/aelin/useUserAvailableToDepositDirectDeal.tsx
+++ b/src/hooks/aelin/useUserAvailableToDepositDirectDeal.tsx
@@ -24,6 +24,8 @@ export type UserPoolBalance = {
   userMaxDepositPrivateAmount: DetailedNumberExtended
   refetchBalances: () => void
   investmentTokenBalance: DetailedNumberExtended
+  userAllowance: DetailedNumberExtended
+  refetchUserAllowance: () => void
 }
 
 export function useUserAvailableToDepositDirectDeal(pool: ParsedAelinPool): UserPoolBalance {
@@ -34,6 +36,13 @@ export function useUserAvailableToDepositDirectDeal(pool: ParsedAelinPool): User
     pool.investmentToken,
     'balanceOf',
     [address || ZERO_ADDRESS],
+  )
+
+  const [userAllowance, refetchUserAllowance] = useERC20Call(
+    pool.chainId,
+    pool.investmentToken,
+    'allowance',
+    [address || ZERO_ADDRESS, pool.address],
   )
 
   const [[allowListValues, userPoolBalance], refetchAllowListBalance] =
@@ -87,10 +96,20 @@ export function useUserAvailableToDepositDirectDeal(pool: ParsedAelinPool): User
       ),
       type: AmountTypes.investmentTokenBalance,
     },
+    userAllowance: {
+      raw: userAllowance || ZERO_BN,
+      formatted: formatToken(
+        userAllowance || ZERO_BN,
+        pool.investmentTokenDecimals,
+        DISPLAY_DECIMALS,
+      ),
+      type: AmountTypes.investmentTokenBalance,
+    },
     userAlreadyInvested,
     refetchBalances: () => {
       refetchUserInvestmentTokenBalance()
       isPrivatePool(pool.poolType) && refetchAllowListBalance()
     },
+    refetchUserAllowance,
   }
 }


### PR DESCRIPTION
to fix that I added `allowance` request to `useUserAvailableToDeposit` and `useUserAvailableToDepositDirectDeal` and then used that data to extend balances in `Deposit` and `DepositDirectDeal`. since we now have `allowance` in hooks, I decided to use them as well in `Invest` and `InvestDirectDeal` to reduce the code (let me know if that's not needed).

here's the result (first screen after clicking max button)
<img width="346" alt="Screenshot 2023-04-14 at 12 29 16" src="https://user-images.githubusercontent.com/22725775/231996681-42622893-dc47-45e1-8e8b-08afa32eb3aa.png">
<img width="351" alt="Screenshot 2023-04-14 at 12 29 27" src="https://user-images.githubusercontent.com/22725775/231996696-c4b26a67-7013-442a-89d3-854e4f1c4ff5.png">
