### PR TITLE
Remove jest warnings issues

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,7 +7,7 @@ const { compilerOptions } = require('./tsconfig.json')
 module.exports = {
   // Use the TypeScript compiler to transpile TypeScript code
   transform: {
-    '^.+\\.(tsx|ts)?$': 'ts-jest',
+    '^.+\\.(tsx|ts)?$': ['ts-jest', { tsconfig: { jsx: 'react-jsx' } }],
   },
 
   // Specify the file patterns for test files
@@ -21,12 +21,4 @@ module.exports = {
 
   // Config re-map imports
   moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, { prefix: '<rootDir>/' }),
-
-  globals: {
-    'ts-jest': {
-      tsConfig: {
-        jsx: 'react-jsx',
-      },
-    },
-  },
 }


### PR DESCRIPTION
This PR aims to remove the following jest warning issues

```
ts-jest[ts-jest-transformer] (WARN) Define `ts-jest` config under `globals` is deprecated. Please do
transform: {
    <transform_regex>: ['ts-jest', { /* ts-jest config goes here in Jest */ }],
},
ts-jest[backports] (WARN) "[jest-config].globals.ts-jest.tsConfig" is deprecated, use "[jest-config].globals.ts-jest.tsconfig" instead.
ts-jest[backports] (WARN) Your Jest configuration is outdated. Use the CLI to help migrating it: ts-jest config:migrate <config-file>.
ts-jest[ts-jest-transformer] (WARN) Define `ts-jest` config under `globals` is deprecated. Please do
transform: {
    <transform_regex>: ['ts-jest', { /* ts-jest config goes here in Jest */ }],
},
ts-jest[backports] (WARN) "[jest-config].globals.ts-jest.tsConfig" is deprecated, use "[jest-config].globals.ts-jest.tsconfig" instead.
ts-jest[backports] (WARN) Your Jest configuration is outdated. Use the CLI to help migrating it: ts-jest config:migrate <config-file>.
```